### PR TITLE
fix state persistence

### DIFF
--- a/Sources/SpeziOneSec/SpeziOneSec.swift
+++ b/Sources/SpeziOneSec/SpeziOneSec.swift
@@ -87,11 +87,10 @@ final class SpeziOneSec: SpeziOneSecModule, Module, EnvironmentAccessible, Senda
     }
     
     override func updateState(_ newState: SpeziOneSecModule.State) {
-        super.updateState(newState)
-        guard newState != state else {
-            return
+        if newState != state {
+            try? localStorage.store(newState, for: .speziOneSecState)
         }
-        try? localStorage.store(newState, for: .speziOneSecState)
+        super.updateState(newState)
     }
     
     override func makeSpeziOneSecSheet() -> AnyView {


### PR DESCRIPTION
# fix state persistence

## :recycle: Current situation & Problem
the `state` currently isn't persisted, bc the function returns too early (the super call updates `self.state`, but we then have a check that `newState != state`, which obviously will always be false... this is now fixed.


## :gear: Release Notes
- fix state persistence


## :books: Documentation
n/a


## :white_check_mark: Testing
n/a


### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
