### PR TITLE
sheet improvements

### DIFF
--- a/Sources/SpeziOneSec/StudySurveySheet.swift
+++ b/Sources/SpeziOneSec/StudySurveySheet.swift
@@ -21,8 +21,10 @@ struct StudySurveySheet: View {
     var body: some View {
         if let url = speziOneSec.surveyUrl {
             NavigationStack {
-                WebView(url: url) { webView in
-                    await onNavigation(webView)
+                WebView(url: url) { request in
+                    await shouldNavigate(request)
+                } didNavigate: { webView in
+                    await didNavigate(webView)
                 }
                 .navigationTitle("Stanford Study")
                 .navigationBarTitleDisplayMode(.inline)
@@ -97,7 +99,18 @@ struct StudySurveySheet: View {
         #endif
     }
     
-    private func onNavigation(_ webView: WebViewProxy) async {
+    
+    private func shouldNavigate(_ request: URLRequest) async -> Bool {
+        if request.url?.host() == "one-sec.app" {
+            isDone = true
+            dismiss()
+            return false
+        } else {
+            return true
+        }
+    }
+    
+    private func didNavigate(_ webView: WebViewProxy) async {
         if await webView.pageContainsField(named: "healthkit_export_initiated") {
             await initiateHealthExport()
         } else if await webView.pageContainsElement(withId: "surveyacknowledgment") {


### PR DESCRIPTION
# sheet improvements

## :gear: Release Notes
- the sheet now auto-dismisses itself at the end of the survey flow, ie when we detect that REDCap is about to navigate to the one-sec.app website

## :books: Documentation
n/a

## :white_check_mark: Testing
n/a

### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
