### PR TITLE
sheet page load progress indicators

### DIFF
--- a/Sources/SpeziOneSec/StudySurveySheet.swift
+++ b/Sources/SpeziOneSec/StudySurveySheet.swift
@@ -15,18 +15,28 @@ struct StudySurveySheet: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(SpeziOneSec.self) private var speziOneSec
     
+    @State private var didCompleteInitialNavigation = false
     @State private var isShowingCancelAlert = false
     @State private var isDone = false
+    @State private var currentPageLoadProgress: Double?
     
     var body: some View {
         if let url = speziOneSec.surveyUrl {
             NavigationStack {
-                WebView(url: url) { request in
+                WebView(url: url, currentProgress: $currentPageLoadProgress) { request in
                     await shouldNavigate(request)
                 } didNavigate: { webView in
+                    didCompleteInitialNavigation = true
                     await didNavigate(webView)
                 }
-                .navigationTitle("Stanford Study")
+                .overlay {
+                    if !didCompleteInitialNavigation {
+                        VStack {
+                            ProgressView("Loading…")
+                                .controlSize(.large)
+                        }
+                    }
+                }
                 .navigationBarTitleDisplayMode(.inline)
                 .toolbar {
                     if !isDone {
@@ -36,6 +46,16 @@ struct StudySurveySheet: View {
                     } else {
                         ToolbarItem(placement: .confirmationAction) {
                             confirmButton
+                        }
+                    }
+                    ToolbarItem(placement: .principal) {
+                        VStack(spacing: 4) {
+                            Text("Stanford Study")
+                                .font(.headline)
+                            if let progress = currentPageLoadProgress {
+                                ProgressView(value: progress)
+                                    .progressViewStyle(.linear)
+                            }
                         }
                     }
                 }

--- a/Sources/SpeziOneSec/StudySurveySheet.swift
+++ b/Sources/SpeziOneSec/StudySurveySheet.swift
@@ -31,10 +31,8 @@ struct StudySurveySheet: View {
                 }
                 .overlay {
                     if !didCompleteInitialNavigation {
-                        VStack {
-                            ProgressView("Loading…")
-                                .controlSize(.large)
-                        }
+                        ProgressView("Loading…")
+                            .controlSize(.large)
                     }
                 }
                 .navigationBarTitleDisplayMode(.inline)

--- a/Sources/SpeziOneSec/WebView.swift
+++ b/Sources/SpeziOneSec/WebView.swift
@@ -181,12 +181,12 @@ private struct WebViewImpl: UIViewRepresentable {
         let webView = WKWebView(frame: .zero)
         webView.navigationDelegate = coordinator
         webView.uiDelegate = coordinator
-        coordinator.kvoObservations.append(webView.observe(\.estimatedProgress, options: [.new]) { [weak coordinator] webView, change in
-            guard let coordinator, let progress = change.newValue else {
+        coordinator.kvoObservations.append(webView.observe(\.estimatedProgress, options: [.new]) { [weak coordinator] _, change in
+            guard let coordinator else {
                 return
             }
             MainActor.assumeIsolated {
-                currentProgress = coordinator.isNavigating ? progress : nil
+                currentProgress = coordinator.isNavigating ? change.newValue : nil
             }
         })
         webView.load(URLRequest(url: config.initialUrl))
@@ -222,7 +222,10 @@ extension WebViewImpl {
             }
         }
         
-        func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
+        func webView(
+            _ webView: WKWebView,
+            didStartProvisionalNavigation navigation: WKNavigation! // swiftlint:disable:this implicitly_unwrapped_optional
+        ) {
             isNavigating = true
             parent.currentProgress = 0
         }

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -235,6 +235,9 @@
 			inputFileListPaths = (
 			);
 			inputPaths = (
+				"$(BUILT_PRODUCTS_DIR)/SpeziFoundation_SpeziFoundation.bundle",
+				"$(BUILT_PRODUCTS_DIR)/SpeziHealthKit_SpeziHealthKit.bundle",
+				"$(BUILT_PRODUCTS_DIR)/HealthKitOnFHIR_HealthKitOnFHIR.bundle",
 			);
 			outputFileListPaths = (
 			);


### PR DESCRIPTION
# sheet page load progress indicators

## :recycle: Current situation & Problem
when enrolling into the study on a bad network connection, and, due to REDCap just being slow af, sometimes also when enrolling on a good connection, there can be a state where the sheet just appears empty for several seconds (on the initial page load) or it will appear as if a navigation from page N to page N+1 failed to initiate.

we attempt to fix this, by adding 2 progress indicators:
- during the initial page load (of the first REDCap instrument) we add a large circular "Loading…" progress spinner in the middle of the sheet
- additionally, we also have a small percentage-based progress bar under the navigation title for all page loads. this explicitly is modeled after the iOS 26 behaviour of SFSafariViewController.


## :gear: Release Notes
- enrollment sheet now communicates page loading activity/progress


## :books: Documentation
n/a


## :white_check_mark: Testing
n/a


### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
